### PR TITLE
Add docs for preview environments

### DIFF
--- a/docs/deploying-applications/deploying-from-github/adding-or-updating-porter-gh-app.mdx
+++ b/docs/deploying-applications/deploying-from-github/adding-or-updating-porter-gh-app.mdx
@@ -58,14 +58,26 @@ Note that when you grant access to the Porter Github App, you are granting acces
 
 The Porter Github App requires several Github permissions in order to operate properly:
 
-**Repository permissions**
+### Repository permissions
 
 **Actions (Read & write):** required for Porter to write Github actions YAML files to the repository.
 
+**Administration (Read & write):** required for Porter to create a new Github environment called `Preview` for deployments. The administration API isn't used otherwise.
+
 **Contents (Read & write):** required for Porter to write Github actions YAML files to the repository.
 
+**Deployments (Read & write):** required for Porter to request Github deployments to the `Preview` environment.
+
+**Environments (Read & write):** required for Porter to create a new Github environment called `Preview` for deployments.
+
 **Metadata (Read-only):** mandatory, required for Github apps that integrate with repositories.
+
+**Pull Requests (Read & write):** required for Porter to add comments to Github PRs.
 
 **Secrets (Read & write):** required for Porter to write a `PORTER_TOKEN` secret to the repository automatically. We **do not** read any secrets from the repository beyond those prefixed with `PORTER_`.
 
 **Workflows (Read & write):** required for Porter to write Github actions YAML files to the repository.
+
+### User Permissions
+
+**Email addresses (read-only)**: required for Porter to read your Github email address for authentication.

--- a/docs/preview-environments/examples.mdx
+++ b/docs/preview-environments/examples.mdx
@@ -1,0 +1,28 @@
+---
+id: examples
+slug: /preview-environments/examples
+title: Examples
+---
+
+import Link from "@docusaurus/Link";
+
+This section contains examples that can serve as templates to help you get started with preview environments:
+
+<div class="container" style={{ padding: 0 }}>
+  <div class="row is-multiline">
+    <div class="col col--6">
+      <Link
+        className="card"
+        to="./examples/basic-web-application"
+        style={{ height: "100%" }}
+      >
+        <div class="card__body">
+          <h4>Basic Web Application</h4>
+          <p class="card__body__small">
+            Enable preview environments for a basic web application.
+          </p>
+        </div>
+      </Link>
+    </div>
+  </div>
+</div>

--- a/docs/preview-environments/examples/basic-web-application.mdx
+++ b/docs/preview-environments/examples/basic-web-application.mdx
@@ -1,0 +1,34 @@
+---
+id: basic-web-application
+slug: /preview-environments/examples/basic-web-application
+title: Basic Web Application
+---
+
+In this example, we'll walk through an example of enabling preview environments for a simple Go application, built via a cloud-native buildpack. The sample repository can be found [here](https://github.com/porter-dev/go-getting-started).
+
+## `porter.yaml` File Walkthrough
+
+The `porter.yaml` file for this application is as follows:
+
+```yaml
+version: "v1"
+resources:
+  - name: "go-sample"
+    source:
+      name: "web"
+    config:
+      build:
+        method: "pack"
+      values:
+        container:
+          command: "go-getting-started"
+          port: 8080
+          env:
+            normal:
+              BPE_PORT: "8080"
+              BP_KEEP_FILES: "static/*"
+```
+
+- `source`: By only setting the `source.name` field to `web`, Porter will deploy this as a `web` application.
+- `config.build`: specifying the `config.build.method` field as `pack` instructs Porter to build this application using cloud-native buildpacks.
+- `config.values`: here, we set common configuration settings, such as the start command, the port that the application runs on, and environment variables for the application.

--- a/docs/preview-environments/overview.mdx
+++ b/docs/preview-environments/overview.mdx
@@ -1,7 +1,0 @@
----
-id: overview
-slug: /preview-environments/overview
-title: Overview
----
-
-TODO

--- a/docs/preview-environments/porter-yaml-reference.mdx
+++ b/docs/preview-environments/porter-yaml-reference.mdx
@@ -1,0 +1,108 @@
+---
+id: porter-yaml-reference
+slug: /preview-environments/porter-yaml-reference
+title: Porter YAML Reference
+---
+
+This document contains a full reference file for `porter.yaml`. Each `porter.yaml` file has the following high-level structure:
+
+- [`version`](#version) - the version of the `porter.yaml` file reference to use.
+- [`resources`](#resources) - a list of resources to create.
+  - [`name`](#resourcename) - the name of the resource.
+  - [`depends_on`](#resourcedepends_on) - the resources that the target resources depends on.
+  - [`source`](#resourcesource) - the source configuration, specifying the application/addon to use.
+  - [`config`](#resourceconfig) - the build and runtime configuration for the addon or application.
+
+## `version`
+
+The version of the `porter.yaml` file reference to use. Currently, only `v1` is supported:
+
+```yaml
+version: v1
+```
+
+## `resources`
+
+A list of resources to create. For example:
+
+```yaml
+---
+resources:
+  - name: "resource-1"
+    source:
+      name: "web"
+  - name: "resource-2"
+    depends_on:
+      - "resource-1"
+    source:
+      name: "web"
+```
+
+### `<resource>.name`
+
+The name of the resource to create.
+
+### `<resource>.depends_on`
+
+A list of resources that the target resource depends on.
+
+```yaml
+---
+resources:
+  - name: "resource-1"
+    source:
+      name: "web"
+  - name: "resource-2"
+    depends_on:
+      - "resource-1"
+```
+
+### `<resource>.source`
+
+The source specifies the application/addon to deploy for this resource. More specifically, it uniquely identifies a Helm chart. It contains the following fields:
+
+- `name` \[`String`, required\] - the name of the template to use. Since the default source repo is https://charts.getporter.dev, the names `web`, `worker`, and `job` work by default.
+- `repo` \[`String`, optional\] - the Helm repository URL to use. Currently supported are `https://charts.getporter.dev` and `https://chart-addons.getporter.dev`.
+- `version` \[`String`, optional\] - the semver version of the chart to use. If no version is specified, the latest version is used.
+
+For example, to deploy a worker application:
+
+```yaml
+---
+resources:
+  - name: "web-example"
+    source:
+      name: "worker" # this could also be "web" or "job"
+```
+
+To deploy `postgresql`, a supported addon:
+
+```yaml
+---
+resources:
+  - name: "postgres"
+    source:
+      name: "postgresql"
+      repo: "https://chart-addons.getporter.dev"
+```
+
+### `<resource>.config`
+
+The `config` block specifies build and runtime configuration for the application or addon.
+
+#### Application Config
+
+If the resource is a `web`, `worker`, or `job` application, the `config` block expects the following fields:
+
+- `build` \[required\] - the build configuration to use.
+  - `method` \[`docker`, `pack`, or `registry`\] - the build/deploy method to use: the Docker daemon, cloud-native buildpacks or deployment from a Docker registry.
+  - `dockerfile` \[`String`, optional\] - if the build method is `docker`, the path to the Dockerfile. Defaults to `./Dockerfile`.
+  - `context` \[`String`, optional\] - if the build method is `docker` or `pack`, the path to the application directory. Defaults to the current (root) directory.
+  - `image` \[`String`, required if `method=registry`\] - the image repo URL to deploy from, if the build method is `registry`.
+- `values` \[required\] - the [runtime configuration](#runtime-configuration) to use.
+
+If the resource is an addon, the `config` block corresponds directly to the [runtime configuration](#runtime-configuration).
+
+#### Runtime Configuration
+
+The options for the runtime configuration (`config.values` for applications, `config` for addons) corresponds to the default Helm values for the application. If you have experience with Kubernetes/Helm, you can also view all possible configuration options in the `values.yaml` files of the respective applications: [`web`](https://github.com/porter-dev/porter-charts/blob/master/applications/web/values.yaml), [`worker`](https://github.com/porter-dev/porter-charts/blob/master/applications/worker/values.yaml), and [`job`](https://github.com/porter-dev/porter-charts/blob/master/applications/job/values.yaml). If you don't have this experience, please see the [examples](./examples) to view common configuration options.

--- a/docs/preview-environments/setup.mdx
+++ b/docs/preview-environments/setup.mdx
@@ -1,0 +1,89 @@
+---
+id: setup
+slug: /preview-environments/setup
+title: Setup
+---
+
+:::info Beta Notice
+
+Preview environments are currently in `beta` and are not enabled on Porter projects by default. Please reach out on Discord or over email if you'd like to participate in beta-testing preview environments.
+
+:::
+
+_Preview environments_ are isolated instances of your application used for testing purposes. You can configure Porter to create a preview environment for every new pull request made to your Github repository. There are three steps required to get preview environments working with your application:
+
+- Make sure preview environments are enabled for your cluster
+- Preview environments enabled for your desired Github repository
+- A `porter.yaml` file at the root of your repository
+
+## Enable Preview Environments for your Cluster
+
+To enable preview environments for your cluster, navigate to the [cluster dashboard](https://dashboard.getporter.dev/cluster-dashboard). If preview environments are enabled for your project, you will see the first tab of the cluster listed as **Preview Environments**. Click **Enable Preview Environments** to enable them for your cluster.
+
+## Enable Preview Environments for your Repository
+
+Next, you should enable preview environments for your specific repository. To do this, click on the **Add Repository** button and select the repository that you wish to enable preview environments in. If you're not seeing the correct list of repositories, follow the instructions [here](../deploying-applications/deploying-from-github/adding-or-updating-porter-gh-app.mdx#updating-the-porter-github-app) to add your repository. Then, click **Add Repository** again, and preview environments will be enabled for your repository.
+
+:::info
+
+To remove preview environments from a repository, click on the **Configure** button, which will pull up a list of the repositories where preview environments are currently enabled. Click on the delete icon next to the repository to remove the integration.
+
+:::
+
+## Create a `porter.yaml` File
+
+The last step is to create a `porter.yaml` file for your application. This file specifies the list of applications and addons that you'd like to deploy, and the build configuration settings for your application. Here's an example `porter.yaml` file:
+
+```yaml
+# The YAML reference version: v1 is the only option for now
+version: v1
+
+# A list of resources to create
+resources:
+  - # The name of this resource
+    name: example
+
+    # The source for this repository. Defaults to the web, worker, and job applications by default.
+    source:
+      name: web
+
+    # The configuration for the application or addon.
+    config:
+      # The build configuration for the application.
+      build:
+        method: pack
+      # The runtime configuration for the application.
+      values:
+        container:
+          command: go-getting-started
+          port: 8080
+          env:
+            normal:
+              BPE_PORT: "8080"
+```
+
+Now that the repository has been added and the `porter.yaml` file has been created, new PRs created will trigger a new preview environment, and updates to that PR will re-build and re-deploy the environment. Each time the preview environment is deployed, a Github comment will be added to the PR indicating the URL that the PR is deployed on:
+
+![Bot Comment](https://files.readme.io/c607964-Screen_Shot_2022-01-10_at_7.26.35_PM.png "Bot Comment")
+
+## Github App Permissions
+
+If you previously installed the Porter Github App in your Github account, you will receive an email requesting updated permissions for the Github app. **If you do not wish to test preview environments at this time, you can ignore this email**. The existing Porter Github App will still work.
+
+This section details the **updated permissions** that the Porter Github App is requesting.
+
+:::info
+
+To see the full list of requested permissions, go [here](../deploying-applications/deploying-from-github/adding-or-updating-porter-gh-app.mdx#porter-github-app-permissions).
+
+:::
+
+### Repository permissions
+
+**Administration (Read & write):** required for Porter to create a new Github environment called `Preview` for deployments. The administration API isn't used otherwise.
+
+**Deployments (Read & write):** required for Porter to request Github deployments to the `Preview` environment.
+
+**Environments (Read & write):** required for Porter to create a new Github environment called `Preview` for deployments.
+
+**Pull Requests (Read & write):** required for Porter to add comments to Github PRs.

--- a/sidebars.js
+++ b/sidebars.js
@@ -261,12 +261,25 @@ const sidebars = {
       ],
       collapsible: false,
     },
-    // {
-    //   type: "category",
-    //   label: "Preview Environments",
-    //   items: ["preview-environments/overview"],
-    //   collapsible: false,
-    // },
+    {
+      type: "category",
+      label: "Preview Environments",
+      items: [
+        "preview-environments/setup",
+        "preview-environments/porter-yaml-reference",
+        {
+          type: "category",
+          label: "Examples",
+          className: "expandable-subdoc",
+          link: {
+            type: "doc",
+            id: "preview-environments/examples",
+          },
+          items: ["preview-environments/examples/basic-web-application"],
+        },
+      ],
+      collapsible: false,
+    },
     {
       type: "category",
       label: "Other Guides",


### PR DESCRIPTION
Adds docs section for preview environments with a basic example. 

Todo before merge:
- [ ] Update examples section with at least 2 more examples (one with addon), make sure go-getting-started repo is correct