### PR TITLE
Update installation scripts to improve simplicity

### DIFF
--- a/docs/command-line-interface/_linux-installation.mdx
+++ b/docs/command-line-interface/_linux-installation.mdx
@@ -1,33 +1,5 @@
-Run the following command to grab the latest binary:
+#### Manual Installation
 
-```sh
-{
-name=$(curl -s https://api.github.com/repos/porter-dev/porter/releases/latest | grep "browser_download_url.*/porter_.*_Linux_x86_64\.zip" | cut -d ":" -f 2,3 | tr -d \")
-name=$(basename $name)
-curl -L https://github.com/porter-dev/porter/releases/latest/download/$name --output $name
-unzip -a $name
-rm $name
-}
 ```
-
-Then move the file into your bin:
-
-```sh
-chmod +x ./porter
-sudo mv ./porter /usr/local/bin/porter
-```
-
-To download a specific version of the CLI:
-
-```sh
-{
-# NOTE: replace this line with the version
-version=v0.6.1
-name=porter-$version.zip
-curl -L https://github.com/porter-dev/porter/releases/download/${version}/porter_${version}_Linux_x86_64.zip --output $name
-unzip -a $name
-rm $name
-chmod +x ./porter
-sudo mv ./porter /usr/local/bin/porter
-}
+/bin/bash -c "$(curl -fsSL https://install.porter.run)"
 ```

--- a/docs/command-line-interface/_mac-installation.mdx
+++ b/docs/command-line-interface/_mac-installation.mdx
@@ -2,38 +2,8 @@
 
 To install via `brew`, simply run `brew install porter-dev/porter/porter`.
 
-#### Direct Download
+#### Manual Installation
 
-Run the following script to grab the latest binary:
-
-```sh
-{
-name=$(curl -s https://api.github.com/repos/porter-dev/porter/releases/latest | grep "browser_download_url.*/porter_.*_Darwin_x86_64\.zip" | cut -d ":" -f 2,3 | tr -d \")
-name=$(basename $name)
-curl -L https://github.com/porter-dev/porter/releases/latest/download/$name --output $name
-unzip -a $name
-rm $name
-}
 ```
-
-Then move the file into your bin:
-
-```sh
-chmod +x ./porter
-sudo mv ./porter /usr/local/bin/porter
-```
-
-To download a specific version of the CLI:
-
-```sh
-{
-# NOTE: replace this line with the version
-version=v0.6.1
-name=porter-$version.zip
-curl -L https://github.com/porter-dev/porter/releases/download/${version}/porter_${version}_Darwin_x86_64.zip --output $name
-unzip -a $name
-rm $name
-chmod +x ./porter
-sudo mv ./porter /usr/local/bin/porter
-}
+/bin/bash -c "$(curl -fsSL https://install.porter.run)"
 ```

--- a/docs/command-line-interface/_windows-installation.mdx
+++ b/docs/command-line-interface/_windows-installation.mdx
@@ -1,1 +1,9 @@
+To use Porter on Windows, we hightly recommend installing Porter on WSL via:
+
+```
+/bin/bash -c "$(curl -fsSL https://install.porter.run)"
+```
+
+#### Manual Installation
+
 Go [here](https://github.com/porter-dev/porter/releases/latest) to download the Windows executable and add the binary to your `PATH`.


### PR DESCRIPTION
Using the new `install.porter.run` domain, manual installations are much easier now. 