### PR TITLE
Deleting dangling resources

### DIFF
--- a/docs/other/deleting-dangling-resources.mdx
+++ b/docs/other/deleting-dangling-resources.mdx
@@ -14,11 +14,15 @@ Please note that the instructions in the following sections need to be used in t
 
 Go to the **EKS** section on your AWS console, and delete the cluster in question, if it's visible.
 
+![EKS](https://imagedelivery.net/l4LYM_vOYKe7O1NCT_Nc_g/86a228b3-68d5-4e42-912b-a34a51f6d600/large "Screen Shot 2021-03-26 at 4.16.01 PM.png")
+
 ### Removing Auto Scaling Groups & Launch Configurations
 
 On the **EC2** dashboard, navigate to the **Auto Scaling Groups** section, and remove any auto scaling groups that contain your cluster's name. Once they're deleted, you need to delete any launch configurations that may be left over, containing your cluster's name.
 
-### Removing Load Balancers
+![Autoscaling group](https://imagedelivery.net/l4LYM_vOYKe7O1NCT_Nc_g/33c10eca-b30b-44c3-8f43-3deae40da300/large "Screen Shot 2021-03-26 at 4.24.08 PM.png")
+
+### Removing Load Balancers & Elastic IPs
 
 First, navigate to the **VPC** section in your AWS console to see the VPC's that are currently in use. Select the VPC that belongs to the cluster you've provisioned, and copy the VPC ID. Then go to the **Load Balancers** section on the **EC2** dashboard, and locate the load balancer for your cluster using the VPC ID you just copied as a filter - delete any load balancers found.
 
@@ -31,29 +35,12 @@ Deleting the EKS cluster and associated auto scaling groups and launch configura
 Navigate to the **VPC** section in your AWS console to see the VPC's that are currently in use. Select the VPC that belongs to the cluster you've provisioned, and copy the VPC ID.
 
 1. Click on **NAT Gateways**, and use the VPC ID to filter out the NAT Gateway for your cluster; select it and then click on **Actions** -> **Delete NAT Gateway**. 
-2. After ensuring the NAT Gateway was deleted, navigate to **Internet Gateways**, and use the VPC ID to locate the Internet Gateway for your cluster; select it and click on **Actions** -> **Detach from VPC**. Once the gateway is detached, select **Actions** -> **Delete Internet gateway**.
-3. 
+![NAT gateway](https://imagedelivery.net/l4LYM_vOYKe7O1NCT_Nc_g/29bcf96e-84ff-4d9d-d3b5-1e15a5554900/large "Screen Shot 2021-03-26 at 4.09.51 PM.png")
+2. After ensuring the NAT Gateway was deleted, navigate to **Internet Gateways**, and use the VPC ID to locate the Internet Gateway for your cluster; select it and click on **Actions** -> **Detach from VPC**. Once the gateway is detached, select **Actions** -> **Delete Internet gateway**. If detaching the gateway throws an error about unmapped public IPs, go to the **Elastic IPs** section and release any elastic IPs associated with the VPC ID.
+3. After all gateways have been deleted, go to the **Subnets** section, and remove all subnets associated with the cluster VPC, by clicking on **Actions** -> **Delete subnet**.
+4. Finally, you can delete the VPC by going to **Your VPCs** and deleting the VPC for your cluster, by selecting **Actions** -> **Delete VPC**.
 
 ![Delete VPC](https://imagedelivery.net/l4LYM_vOYKe7O1NCT_Nc_g/e74141e4-6a77-4a08-6ffb-541586499300/large "Screen Shot 2021-03-26 at 4.05.16 PM.png")
 
-AWS might warn you that the VPC cannot be deleted due to existing NAT gateways or network interfaces that are in use. Click on the text **NAT Gateways** to view the NAT gateway in use. Once you delete the NAT gateway, you'll be able to delete the VPC.
 
-![NAT gateway](https://imagedelivery.net/l4LYM_vOYKe7O1NCT_Nc_g/29bcf96e-84ff-4d9d-d3b5-1e15a5554900/large "Screen Shot 2021-03-26 at 4.09.51 PM.png")
 
-### Deleting Elastic IP
-
-Head to the **Elastic IP addresses** section in the VPC tab. Select the EIP of the cluster you have deleted and click **Actions > Release Elastic IP Addresses**.
-
-## Deleting EKS
-
-Head to the **EKS** tab, select the cluster and click **Delete** .
-
-![EKS](https://imagedelivery.net/l4LYM_vOYKe7O1NCT_Nc_g/86a228b3-68d5-4e42-912b-a34a51f6d600/large "Screen Shot 2021-03-26 at 4.16.01 PM.png")
-
-### Deleting Nodes
-
-It sometimes occurs that even after the EKS cluster has been deleted, the actual **EC2 machines** comprising the cluster do not get deleted properly. Navigate to **EC2 > Autoscaling Groups** and ensure that autoscaling groups attached to your cluster has been deleted. **If this autoscaling group persists, AWS will continue to spin back up your nodes even after manual deletion.**
-
-Once you've deleted the **Autoscaling Group**, head to **EC2 > Instances** and delete all the nodes.
-
-![Autoscaling group](https://imagedelivery.net/l4LYM_vOYKe7O1NCT_Nc_g/33c10eca-b30b-44c3-8f43-3deae40da300/large "Screen Shot 2021-03-26 at 4.24.08 PM.png")


### PR DESCRIPTION
Updated the docs on deleting dangling resources on AWS; added a working sequence of instructions for cleaning up EKS, EC2 and VPC resources.