### PR TITLE
B/G deployments

### DIFF
--- a/docs/deploying-applications/blue-green-deployments.mdx
+++ b/docs/deploying-applications/blue-green-deployments.mdx
@@ -1,0 +1,97 @@
+---
+id: blue-green-deployments
+slug: /deploying-applications/blue-green-deployments
+title: Blue/Green deployments
+---
+
+You can configure your apps to be deployed using a blue/green strategy, where Porter spins up an identical number of replicas for your app(the "blue" environment) using a new build, and waits for the entire environment to be up and running, before switching traffic to the new version(the "green" environment). Setting up B/G deployments for your app involves modifying your app's configuration, as well as your build step in your CI system that's reponsible for updating the Porter app after a successful build.
+
+:::warning Setup Sequence
+Please note - this process needs to followed in the same sequence as presented below, and it is a good idea to complete the second step for tweaking your build step right after you've made changes to the Porter app; this will ensure any other builds/revisions will not conflict with B/G deployments.
+:::
+
+## Step 1: Modify your apps on Porter
+
+On the Porter dashboard, navigate to the app you'd like to set this up for, and ensure `DevOps Mode` is selected. The first step is to get the active image tag your app's running - you'll find this in the `Source Settings` section under the `Settings` tab. Note the image tag that's currently selected.
+
+Next, you need to navigate to the tab called `Helm Values`. In this tab, add and modify the config blow below:
+
+```yaml
+bluegreen:
+  activeImageTag: <tag>
+  disablePrimaryDeployment: true
+  enabled: true
+  imageTags:
+    - <tag>
+```
+
+For `<tag>`, you'll need to specify the image tag you noted down earlier. Once done, click `Update Values`, and wait for your app to be refreshed.
+
+## Step 2: Modify your build process
+
+This step involves modifying your CI build process to ensure that instead of using the Porter CLI to simply update the Porter app. In your current build process, you'll see sections that use `porter update config` to update the image tag being used for the app; we need to add an additional step right after this update, which tell Porter to switch traffic to the new version. As an example, let's consider the following Github Action workflow step, that currently simply updates an app on Porter called `web-sample` with the new image tag:
+
+```yaml
+    porter-deploy-app:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@v2.3.4
+            - name: Set Github tag
+              id: vars
+              run: echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
+            - name: Update configuration for webserver-dev
+              uses: porter-dev/porter-cli-action@v0.1.0
+              with:
+                  command: update config --app web-sample --tag ${{ steps.vars.outputs.sha_short }} --stream
+              env:
+                  PORTER_HOST: https://dashboard.getporter.dev
+                  PORTER_CLUSTER: 0000
+                  PORTER_PROJECT: 0000
+                  PORTER_TOKEN: ${{ secrets.PORTER_TOKEN_0000 }}
+```
+
+To enable B/G deployments in this case, we'll simply add an additional step at the end of this block to switch traffic, like so:
+
+```yaml
+    porter-deploy-app:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@v2.3.4
+            - name: Set Github tag
+              id: vars
+              run: echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
+            - name: Update configuration for webserver-dev
+              uses: porter-dev/porter-cli-action@v0.1.0
+              with:
+                  command: update config --app web-sample --tag ${{ steps.vars.outputs.sha_short }} --stream
+              env:
+                  PORTER_HOST: https://dashboard.getporter.dev
+                  PORTER_CLUSTER: 0000
+                  PORTER_PROJECT: 0000
+                  PORTER_TOKEN: ${{ secrets.PORTER_TOKEN_0000 }}
+            - name: Switch traffic to the new app once ready for frontend-dev
+              uses: porter-dev/porter-cli-action@v0.1.0
+              with:
+                command: deploy blue-green-switch --app web-sample --tag ${{ steps.vars.outputs.sha_short }}
+              env:
+                PORTER_HOST: https://dashboard.getporter.dev
+                PORTER_CLUSTER: 0000
+                PORTER_PROJECT: 0000
+                PORTER_TOKEN: ${{ secrets.PORTER_TOKEN_0000 }}
+```
+
+Once you've saved this and triggered a new set of builds, your CI runner will be able to specify a "green" version of your app, and switch traffic to it once the "green" version is ready. 
+
+:::warning Environment
+You'll need to ensure that `PORTER_HOST`, `PORTER_CLUSTER`, `PORTER_PROJECT` and `PORTER_TOKEN` are set correctly - you can reuse the same values as in your existing CI definition. 
+:::
+
+## Multiple Revisions
+
+When your app's being deploued using the B/G deployment strategy, you'll notice that each deployment causes your app to jump by three revisions:
+
+1. The first revision runs both "blue" and "green" versions in parallel, with traffic being directed towards the "blue" version.
+2. The second revision runs both "blue" and "green" versions in parallel, with traffic being directed towards the "green" version.
+3. The third - and final - revision removes the "blue" version, after verifying that traffic has been switched properly from "blue" to "green".

--- a/docs/deploying-applications/blue-green-deployments.mdx
+++ b/docs/deploying-applications/blue-green-deployments.mdx
@@ -1,7 +1,7 @@
 ---
 id: blue-green-deployments
 slug: /deploying-applications/blue-green-deployments
-title: Blue/Green deployments
+title: Blue/Green Deployments
 ---
 
 You can configure your apps to be deployed using a blue/green strategy, where Porter will keep the older version of your app running(the "blue" version), while it spins up an identical number of replicas for your app using a new build(the "green" version), and waits for the entire environment to be up and running, before switching traffic from the old version("blue") to the new version("green"). Setting up B/G deployments for your app involves modifying your app's configuration, as well as your build step in your CI system that's reponsible for updating the Porter app after a successful build.

--- a/docs/deploying-applications/blue-green-deployments.mdx
+++ b/docs/deploying-applications/blue-green-deployments.mdx
@@ -4,9 +4,9 @@ slug: /deploying-applications/blue-green-deployments
 title: Blue/Green Deployments
 ---
 
-You can configure your apps to be deployed using a blue/green strategy, where Porter will keep the older version of your app running(the "blue" version), while it spins up an identical number of replicas for your app using a new build(the "green" version), and waits for the entire environment to be up and running, before switching traffic from the old version("blue") to the new version("green"). Setting up B/G deployments for your app involves modifying your app's configuration, as well as your build step in your CI system that's reponsible for updating the Porter app after a successful build.
+You can configure your apps to be deployed using a blue/green strategy, where Porter will keep the older version of your app running (the "blue" version), while it spins up an identical number of replicas for your app using a new build (the "green" version), and waits for the entire environment to be up and running, before switching traffic from the old version ("blue") to the new version ("green"). Setting up B/G deployments for your app involves modifying your app's configuration, as well as your build step in your CI system that's responsible for updating the Porter app after a successful build.
 
-:::warning Setup Sequence
+:::info Setup Sequence
 Please note - this process needs to followed in the same sequence as presented below, and it is a good idea to complete the second step for tweaking your build step right after you've made changes to the Porter app; this will ensure any other builds/revisions will not conflict with B/G deployments.
 :::
 
@@ -42,7 +42,7 @@ As an example, let's consider the following Github Action workflow step, that cu
             - name: Set Github tag
               id: vars
               run: echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
-            - name: Update configuration for webserver-dev
+            - name: Update configuration for web-sample
               uses: porter-dev/porter-cli-action@v0.1.0
               with:
                   command: update config --app web-sample --tag ${{ steps.vars.outputs.sha_short }} --stream
@@ -64,7 +64,7 @@ To enable B/G deployments in this case, we'll just add an additional step at the
             - name: Set Github tag
               id: vars
               run: echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
-            - name: Update configuration for webserver-dev
+            - name: Update configuration for web-sample
               uses: porter-dev/porter-cli-action@v0.1.0
               with:
                   command: update config --app web-sample --tag ${{ steps.vars.outputs.sha_short }} --stream
@@ -73,7 +73,7 @@ To enable B/G deployments in this case, we'll just add an additional step at the
                   PORTER_CLUSTER: 0000
                   PORTER_PROJECT: 0000
                   PORTER_TOKEN: ${{ secrets.PORTER_TOKEN_0000 }}
-            - name: Switch traffic to the new app once ready for frontend-dev
+            - name: Switch traffic to the new app once ready for web-sample
               uses: porter-dev/porter-cli-action@v0.1.0
               with:
                 command: deploy blue-green-switch --app web-sample --tag ${{ steps.vars.outputs.sha_short }}
@@ -86,7 +86,7 @@ To enable B/G deployments in this case, we'll just add an additional step at the
 
 Once you've saved this and triggered a new set of builds, your CI runner will be able to specify a "green" version of your app, and switch traffic to it once the "green" version is ready. 
 
-:::warning Environment
+:::info Environment
 You'll need to ensure that `PORTER_HOST`, `PORTER_CLUSTER`, `PORTER_PROJECT` and `PORTER_TOKEN` are set correctly - you can reuse the same values as in your existing CI definition. 
 :::
 

--- a/docs/deploying-applications/blue-green-deployments.mdx
+++ b/docs/deploying-applications/blue-green-deployments.mdx
@@ -4,7 +4,7 @@ slug: /deploying-applications/blue-green-deployments
 title: Blue/Green deployments
 ---
 
-You can configure your apps to be deployed using a blue/green strategy, where Porter spins up an identical number of replicas for your app(the "blue" environment) using a new build, and waits for the entire environment to be up and running, before switching traffic to the new version(the "green" environment). Setting up B/G deployments for your app involves modifying your app's configuration, as well as your build step in your CI system that's reponsible for updating the Porter app after a successful build.
+You can configure your apps to be deployed using a blue/green strategy, where Porter will keep the older version of your app running(the "blue" version), while it spins up an identical number of replicas for your app using a new build(the "green" version), and waits for the entire environment to be up and running, before switching traffic from the old version("blue") to the new version("green"). Setting up B/G deployments for your app involves modifying your app's configuration, as well as your build step in your CI system that's reponsible for updating the Porter app after a successful build.
 
 :::warning Setup Sequence
 Please note - this process needs to followed in the same sequence as presented below, and it is a good idea to complete the second step for tweaking your build step right after you've made changes to the Porter app; this will ensure any other builds/revisions will not conflict with B/G deployments.
@@ -29,7 +29,9 @@ For `<tag>`, you'll need to specify the image tag you noted down earlier. Once d
 
 ## Step 2: Modify your build process
 
-This step involves modifying your CI build process to ensure that instead of using the Porter CLI to simply update the Porter app. In your current build process, you'll see sections that use `porter update config` to update the image tag being used for the app; we need to add an additional step right after this update, which tell Porter to switch traffic to the new version. As an example, let's consider the following Github Action workflow step, that currently simply updates an app on Porter called `web-sample` with the new image tag:
+This step involves modifying your CI build process to ensure that instead of using the Porter CLI to simply update the Porter app. In your current build process, you'll see sections that use `porter update config` to update the image tag being used for the app; we need to add an additional step right after this update, which tells Porter to switch traffic to the new version. 
+
+As an example, let's consider the following Github Action workflow step, that currently simply updates an app on Porter called `web-sample` with the new image tag:
 
 ```yaml
     porter-deploy-app:
@@ -51,7 +53,7 @@ This step involves modifying your CI build process to ensure that instead of usi
                   PORTER_TOKEN: ${{ secrets.PORTER_TOKEN_0000 }}
 ```
 
-To enable B/G deployments in this case, we'll simply add an additional step at the end of this block to switch traffic, like so:
+To enable B/G deployments in this case, we'll just add an additional step at the end of this block to switch traffic, like so:
 
 ```yaml
     porter-deploy-app:
@@ -90,7 +92,7 @@ You'll need to ensure that `PORTER_HOST`, `PORTER_CLUSTER`, `PORTER_PROJECT` and
 
 ## Multiple Revisions
 
-When your app's being deploued using the B/G deployment strategy, you'll notice that each deployment causes your app to jump by three revisions:
+When your app's being deployed using the B/G deployment strategy, you'll notice that each deployment causes your app to jump by three revisions:
 
 1. The first revision runs both "blue" and "green" versions in parallel, with traffic being directed towards the "blue" version.
 2. The second revision runs both "blue" and "green" versions in parallel, with traffic being directed towards the "green" version.

--- a/sidebars.js
+++ b/sidebars.js
@@ -113,6 +113,7 @@ const sidebars = {
         },
         "deploying-applications/using-other-ci-tools",
         "deploying-applications/zero-downtime-deployments",
+        "deploying-applications/blue-green-deployments",
         "deploying-applications/environment-groups",
         {
           type: "category",


### PR DESCRIPTION
In line with POR-646, added a doc that walks through setting up B/G deployments on Porter.