### PR TITLE
Update minimum permissions needed for AWS provisioning

### DIFF
--- a/docs/getting-started/provisioning-on-aws.mdx
+++ b/docs/getting-started/provisioning-on-aws.mdx
@@ -48,14 +48,17 @@ Copy and paste the below JSON to the field.
       "Action": [
         "autoscaling:AttachInstances",
         "autoscaling:CancelInstanceRefresh",
+        "autoscaling:CompleteLifecycleAction",
         "autoscaling:CreateAutoScalingGroup",
         "autoscaling:CreateLaunchConfiguration",
         "autoscaling:CreateOrUpdateTags",
         "autoscaling:DeleteAutoScalingGroup",
         "autoscaling:DeleteLaunchConfiguration",
+        "autoscaling:DeleteLifecycleHook",
         "autoscaling:DeleteTags",
         "autoscaling:Describe*",
         "autoscaling:DetachInstances",
+        "autoscaling:PutLifecycleHook",
         "autoscaling:SetDesiredCapacity",
         "autoscaling:StartInstanceRefresh",
         "autoscaling:UpdateAutoScalingGroup",
@@ -137,6 +140,12 @@ Copy and paste the below JSON to the field.
         "eks:ListNodegroups",
         "eks:UpdateNodegroupConfig",
         "eks:UpdateNodegroupVersion",
+        "events:PutRule",
+        "events:PutTargets",
+        "events:ListTargetsByRule",
+        "events:DescribeRule",
+        "events:DeleteRule",
+        "events:RemoveTargets",
         "iam:AddRoleToInstanceProfile",
         "iam:AttachRolePolicy",
         "iam:CreateInstanceProfile",
@@ -167,10 +176,13 @@ Copy and paste the below JSON to the field.
         "iam:TagRole",
         "iam:UntagRole",
         "iam:UpdateAssumeRolePolicy",
+        "lambda:*",
         "logs:CreateLogGroup",
+        "logs:CreateLogStream",
         "logs:DescribeLogGroups",
         "logs:DeleteLogGroup",
         "logs:ListTagsLogGroup",
+        "logs:PutLogEvents",
         "logs:PutRetentionPolicy",
         "kms:CreateAlias",
         "kms:CreateGrant",
@@ -184,6 +196,19 @@ Copy and paste the below JSON to the field.
         "kms:ScheduleKeyDeletion"
       ],
       "Resource": "*"
+    },
+    {
+      "Sid": "VisualEditor1",
+      "Effect": "Allow",
+      "Action": [
+        "iam:CreateAccessKey",
+        "iam:DeleteAccessKey",
+        "iam:ListAccessKeys",
+        "iam:CreateUser",
+        "iam:GetUser",
+        "iam:DeleteUser"
+      ],
+      "Resource": "arn:aws:iam::*:user/eks-node-drainer-*"
     }
   ]
 }


### PR DESCRIPTION
Recent changes to enable graceful node shutdown require a permissions update. 